### PR TITLE
Install logrotate to fix unbound LXC

### DIFF
--- a/install/unbound-install.sh
+++ b/install/unbound-install.sh
@@ -19,7 +19,8 @@ $STD apt-get install -y \
   curl \
   mc \
   wget \
-  openssh-server
+  openssh-server \
+  logrotate
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Unbound"

--- a/json/unbound.json
+++ b/json/unbound.json
@@ -36,5 +36,5 @@
             "type": "info"
         }
     ],
-    "status": "🚧"
+    "status": "✅"
 }


### PR DESCRIPTION
## ✍️ Description  
This PR installs `logrotate` before installing `unbound` which configures the service which is missing currently.

I believe this is installed by default in the non-ARM Debian LXC but doesn't seem to be on ARM.

I've tested this locally and I can now spin up an Unbound LXC on my Pi 4 🙂 

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  
