### PR TITLE
Fix typo in misc/install.func

### DIFF
--- a/misc/install.func
+++ b/misc/install.func
@@ -201,7 +201,7 @@ EOF
 
   if [[ -n "${SSH_AUTHORIZED_KEY}" ]]; then
     mkdir -p /root/.ssh
-    echo "${SSH_AUTHORIZED_KfEY}" >/root/.ssh/authorized_keys
+    echo "${SSH_AUTHORIZED_KEY}" >/root/.ssh/authorized_keys
     chmod 700 /root/.ssh
     chmod 600 /root/.ssh/authorized_keys
   fi


### PR DESCRIPTION
Fix typo: SSH_AUTHORIZED_KfEY -> SSH_AUTHORIZED_KEY

## ✍️ Description  
Fixed a typo in main/install.func that caused unbound variable error: SSH_AUTHORIZED_KfEY -> SSH_AUTHORIZED_KEY

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
