### PR TITLE
Fix unbound template path variable

### DIFF
--- a/misc/create_lxc.sh
+++ b/misc/create_lxc.sh
@@ -172,35 +172,35 @@ fi
 # Get LXC template string
 if [ $PCT_OSTYPE = debian ]; then
   if [ $PCT_OSVERSION = 11 ]; then
-    TEMPLATE_VARIENT=bullseye
+    TEMPLATE_VARIANT=bullseye
   else
-    TEMPLATE_VARIENT=bookworm
+    TEMPLATE_VARIANT=bookworm
   fi
 elif [ $PCT_OSTYPE = alpine ]; then
-  TEMPLATE_VARIENT=3.19
+  TEMPLATE_VARIANT=3.19
 else
   if [ $PCT_OSVERSION = 20.04 ]; then
-    TEMPLATE_VARIENT=focal
+    TEMPLATE_VARIANT=focal
   elif [ $PCT_OSVERSION = 24.04 ]; then
-    TEMPLATE_VARIENT=noble
+    TEMPLATE_VARIANT=noble
   elif [ $PCT_OSVERSION = 24.10 ]; then
-    TEMPLATE_VARIENT=oracular
+    TEMPLATE_VARIANT=oracular
   else
-    TEMPLATE_VARIENT=jammy
+    TEMPLATE_VARIANT=jammy
   fi
 fi
 
 if [ -d "/var/lib/vz/template/cache" ]; then 
-  TEMPLATE=$PCT_OSTYPE-$TEMPLATE_VARIENT-rootfs.tar.xz
+  TEMPLATE=$PCT_OSTYPE-$TEMPLATE_VARIANT-rootfs.tar.xz
   TEMPLATE_PATH="$(pvesm path "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" 2>/dev/null || echo "/var/lib/vz/template/cache/${TEMPLATE}")"
   # Download template if needed
   if [ ! -f "$TEMPLATE_PATH" ]; then
     if [ $PCT_OSTYPE = debian ]; then
       msg_info "Downloading LXC Template"
-      wget -q $(curl -s https://api.github.com/repos/asylumexp/debian-ifupdown2-lxc/releases/latest | grep download | grep debian-$TEMPLATE_VARIENT-arm64-rootfs.tar.xz | cut -d\" -f4) -O "$TEMPLATE_PATH" -q || exit "A problem occurred while downloading the LXC template."
+      wget -q $(curl -s https://api.github.com/repos/asylumexp/debian-ifupdown2-lxc/releases/latest | grep download | grep debian-$TEMPLATE_VARIANT-arm64-rootfs.tar.xz | cut -d\" -f4) -O "$TEMPLATE_PATH" -q || exit "A problem occurred while downloading the LXC template."
       msg_ok "Downloaded LXC Template"
     else
-      templateurl="https://jenkins.linuxcontainers.org/job/image-$PCT_OSTYPE/architecture=arm64,release=$TEMPLATE_VARIENT,variant=default/lastStableBuild/artifact/rootfs.tar.xz"
+      templateurl="https://jenkins.linuxcontainers.org/job/image-$PCT_OSTYPE/architecture=arm64,release=$TEMPLATE_VARIANT,variant=default/lastStableBuild/artifact/rootfs.tar.xz"
       msg_info "Downloading LXC Template"
       wget $templateurl -O "$TEMPLATE_PATH" -q || exit "A problem occurred while downloading the LXC template."
       msg_ok "Downloaded LXC Template"
@@ -214,10 +214,10 @@ else
   if [ $PCT_OSTYPE = debian ]; then
     msg_error "Debian unsupported with this download method. Exiting."
   elif [ $PCT_OSTYPE = alpine ]; then
-    $TEMPLATE_VARIENT = 3.18
+    $TEMPLATE_VARIANT = 3.18
   fi
 
-  TEMPLATE="$(pveam available | grep -E "arm64.*$PCT_OSTYPE-$TEMPLATE_VARIENT" | sed 's/arm64[[:space:]]*//')"
+  TEMPLATE="$(pveam available | grep -E "arm64.*$PCT_OSTYPE-$TEMPLATE_VARIANT" | sed 's/arm64[[:space:]]*//')"
   TEMPLATE_PATH="$(pvesm path "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" 2>/dev/null || echo "/var/lib/vz/template/cache/${TEMPLATE}")"
 
   # Download LXC template if needed


### PR DESCRIPTION
## ✍️ Description  
Fixes exit due to unbound `TEMPLATE_PATH` variable in `misc/create_lxc.sh`.
This [variable assignment](https://github.com/community-scripts/ProxmoxVE/blob/ca6b1a95dd59d43f14f2e6fb9aba33453fb95c69/misc/create_lxc.sh#L277) seems to have disappeared in (what looks like) a merge conflict in commit 6249213.

Also fixed some typos in the word `'occur{=>r}ed'` along the way.

## 🔗 Related PR / Discussion / Issue  

Link:

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
