### PR TITLE
Wallos: add `cron` installation step

### DIFF
--- a/install/wallos-install.sh
+++ b/install/wallos-install.sh
@@ -44,7 +44,7 @@ $STD curl http://localhost/endpoints/db/migrate.php
 msg_ok "Installed Wallos"
 
 msg_info "Setting up Crontabs"
-apt-get -y install cron
+$STD apt-get -y install cron
 mkdir -p /var/log/cron
 cat <<EOF >/opt/wallos.cron
 0 1 * * * php /opt/wallos/endpoints/cronjobs/updatenextpayment.php >> /var/log/cron/updatenextpayment.log 2>&1


### PR DESCRIPTION
## ✍️ Description  

`cron` installation step was missed so it was causing error:
```
[ERROR] in line 58: exit code 0: while executing command crontab /opt/wallos.cron

[ERROR] in line 1360: exit code 0: while executing command lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL https://raw.githubusercontent.com/asylumexp/Proxmox/main/install/"$var_install".sh)"
```

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  
