### PR TITLE
Update Alpine version from 3.19 to 3.22

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3189,7 +3189,7 @@ create_lxc_container() {
       esac
       ;;
     alpine)
-       echo "3.19"
+       echo "3.22"
       ;;
     ubuntu)
       case "$version" in


### PR DESCRIPTION
## ✍️ Description  
Bump Alpine from 3.19 to 3.22 to allow downloading and creation of containers without 404

## 🔗 Related PR / Discussion / Issue  

Link: #181 

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 📋 Additional Information (optional)  
Very, very simple fix, changing 2 characters
