### PR TITLE
fix amd64 architecture to arm64 for Semaphore UI package install script

### DIFF
--- a/ct/semaphore.sh
+++ b/ct/semaphore.sh
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop semaphore
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "semaphore" "semaphoreui/semaphore" "binary" "latest" "/opt/semaphore" "semaphore_*_linux_amd64.deb"
+    fetch_and_deploy_gh_release "semaphore" "semaphoreui/semaphore" "binary" "latest" "/opt/semaphore" "semaphore_*_linux_arm64.deb"
 
     msg_info "Starting Service"
     systemctl start semaphore


### PR DESCRIPTION
## ✍️ Description  
Update the install script for Semaphore to use the ARM64 architecture instead of ADM64 as it currently uses.

## 🔗 Related PR / Discussion / Issue  

Link: #184

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [] **Testing performed** – Changes have been thoroughly tested and verified.  

## 📋 Additional Information (optional)  
Only changes one line involving the link to the Semaphore UI package, as based on install guidance from [https://semaphoreui.com/docs/administration-guide/installation/package-manager](https://semaphoreui.com/docs/administration-guide/installation/package-manager)
