### PR TITLE
Fix Jackett updating with AMDx64 build

### DIFF
--- a/ct/jackett.sh
+++ b/ct/jackett.sh
@@ -40,7 +40,7 @@ EOF
     systemctl stop jackett
     msg_ok "Stopped Service"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "jackett" "Jackett/Jackett" "prebuild" "latest" "/opt/Jackett" "Jackett.Binaries.LinuxAMDx64.tar.gz"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "jackett" "Jackett/Jackett" "prebuild" "latest" "/opt/Jackett" "Jackett.Binaries.LinuxARM64.tar.gz"
 
     msg_info "Starting Service"
     systemctl start jackett


### PR DESCRIPTION
## ✍️ Description  
This fixes the Jackett update script to download the ARM64 build instead of the AMDx64.

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified. 
