### PR TITLE
Fix jq command to correctly parse NODE_VERSION

### DIFF
--- a/install/homarr-install.sh
+++ b/install/homarr-install.sh
@@ -21,7 +21,7 @@ $STD apt install -y \
   openssl
 msg_ok "Installed Dependencies"
 
-NODE_VERSION=$(curl -s https://raw.githubusercontent.com/homarr-labs/homarr/dev/package.json | jq -	r '.engines.node | split(">=")[1] | split(".")[0]')
+NODE_VERSION=$(curl -s https://raw.githubusercontent.com/homarr-labs/homarr/dev/package.json | jq -r '.engines.node | split(">=")[1] | split(".")[0]')
 setup_nodejs
 fetch_and_deploy_gh_release "homarr" "homarr-labs/homarr" "prebuild" "latest" "/opt/homarr" "build-debian-arm64.tar.gz"
 


### PR DESCRIPTION
Removed spurious space that was breaking the homarr install  script

## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
